### PR TITLE
Error handling

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -42,6 +42,8 @@ interface options {
   onResize?: (container?: HTMLElement, activeItem?: item) => void;
   /** Executes when an image is clicked. Return a truthy value to prevent zooming. Supplies `container` and `activeItem`. */
   onImageClick?: (container?: HTMLElement, activeItem?: item) => any;
+  /** Executes when an error is thrown when loading an item (image, audio, video or iframe). */
+  onError?: (container?: HTMLElement, activeItem?: item, error?: Error) => void;
 }
 
 interface item {

--- a/readme.md
+++ b/readme.md
@@ -230,6 +230,12 @@ Executes when an image is clicked. Return a truthy value to prevent zooming. Sup
 
 This method was added to make it easier to open a full screen instance when an image is clicked within an inline gallery ([example CodeSandbox](https://codesandbox.io/s/bp-inline-second-instance-forked-ezfzfv)), but could be used for other purposes.
 
+### onError
+
+Type: `function`
+
+Executes when an error is thrown when loading an item (image, audio, video or iframe). Supplies `container`, `activeItem` and `error`.
+
 ## Item Properties
 
 ### width

--- a/src/bigger-picture.svelte
+++ b/src/bigger-picture.svelte
@@ -199,7 +199,7 @@
 			image.sizes = opts.sizes || `${calculateDimensions(item)[0]}px`
 			image.srcset = item.img
 			item.preload = true
-			return image.decode()
+			return image.decode().catch((error) => {})
 		}
 	}
 

--- a/src/components/iframe.svelte
+++ b/src/components/iframe.svelte
@@ -5,7 +5,7 @@
 
 	let loaded, dimensions
 
-	const { activeItem } = props
+	const { activeItem, opts, container } = props
 
 	const setDimensions = () =>
 		(dimensions = props.calculateDimensions(activeItem))
@@ -30,6 +30,7 @@
 		allow="autoplay; fullscreen"
 		title={activeItem.title}
 		on:load={() => (loaded = true)}
+		on:error={(error) => opts.onError?.(container, activeItem, error)}
 	/>
 	<Loading thumb={activeItem.thumb} {loaded} />
 </div>

--- a/src/components/image.svelte
+++ b/src/components/image.svelte
@@ -369,6 +369,7 @@
 				srcset={activeItem.img}
 				sizes={opts.sizes || `${sizes}px`}
 				alt={activeItem.alt}
+				on:error={(error) => opts.onError?.(container, activeItem, error)}
 				out:fly
 			/>
 		{/if}

--- a/src/components/video.svelte
+++ b/src/components/video.svelte
@@ -12,7 +12,7 @@
 
 	let loaded, dimensions
 
-	const { activeItem } = props
+	const { activeItem, opts, container } = props
 
 	const setDimensions = () =>
 		(dimensions = props.calculateDimensions(activeItem))
@@ -53,12 +53,15 @@
 				// add sources / tracks to media element
 				const el = element(tag)
 				addAttributes(el, obj)
+				if(tag == 'source'){
+					listen(el, 'error', (error) => opts.onError?.(container, activeItem, error))
+				}
 				append(mediaElement, el)
 			}
 		}
 		appendToVideo('source', activeItem.sources)
 		appendToVideo('track', activeItem.tracks || [])
-		listen(mediaElement, 'canplay', () => (loaded = true))
+		listen(mediaElement, 'canplay', () => (loaded = true))		
 		append(node, mediaElement)
 	}
 </script>


### PR DESCRIPTION
Added a callback for error handling, e.g. to display a message instead of the failed item (that's what I'm using it for in our app).

Will get called for `error` events on:
- `img` tags: will happen if image fails to load or decode (unknown format). Note that the preloading will fail silently, because the error will be thrown again when displaying, and it makes more sense to handle it when the item is expected to be displayed.
- `source` tags in audio or video items: if the media item fails to load or play (unknown format)
- `iframe` tags: any error. _I didn't test this one._

The callback gets `container` and `activeItem` like all the others already present, plus the error itself.

I'm using Windows so I didn't commit the build outputs because they are different from yours (backslashes etc.). Let me know if I should change something else.